### PR TITLE
sudo isn't required when using Homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ sudo yum install curl autoconf automake libtool python-devel pkgconfig
 ```
 **On Mac OSX**
 ```
-sudo brew install curl autoconf automake libtool pkg-config
+brew install curl autoconf automake libtool pkg-config
 ```
 
 **Installing libpostal**


### PR DESCRIPTION
Homebrew returns an error when using `sudo`:

```
Error: Running Homebrew as root is extremely dangerous and no longer supported.
As Homebrew does not drop privileges on installation you would be giving all
build scripts full access to your system.
```