### PR TITLE
Add Windows install instructions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ To install the Python library, just run:
 pip install postal
 ```
 
+**Installing libpostal on Windows**
+
+Install [msys2](http://msys2.org) and launch a shell using the `MSYS2 MingW 64-bit` start menu option. Then:
+```
+pacman -S autoconf automake curl git make libtool gcc mingw-w64-x86_64-gcc
+git clone https://github.com/openvenues/libpostal
+cd libpostal
+cp -rf windows/* ./
+./bootstrap.sh
+./configure --datadir=[...some dir with a few GB of space...]
+make
+make install
+```
+
+Now start a command prompt which has access to the Microsoft toolchain. This can be done by e.g. installing the [Windows 10 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk) and then running the ``x64 Native Tools Command Prompt``.
+
+Assuming your MSYS and Python are installed in some standard locations, you can use this command prompt to build+install the Python library like so:
+```
+lib.exe /def:libpostal.def /out:libpostal.lib /machine:x64
+pip install postal --global-option=build_ext --global-option="-IC:\msys64\usr\include" --global-option="-L[...libpostal checkout...]"
+copy src\.libs\libpostal-1.dll "C:\Python36\Lib\site-packages\postal\libpostal.dll"
+```
+
 Compatibility
 -------------
 


### PR DESCRIPTION
Note that the instructions won't work as written right now. This is because I need to land a PR in libpostal with a small fix to the Windows build (the .def file is missing some exports). Should send this very shortly.