### PR TITLE
Enable datadir ENV variable

### DIFF
--- a/postal/pydedupe.c
+++ b/postal/pydedupe.c
@@ -526,9 +526,12 @@ init_dedupe(void) {
         INITERROR;
     }
 
-    if (!libpostal_setup() || !libpostal_setup_language_classifier()) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Error loading libpostal");
+   char* datadir = getenv("LIBPOSTAL_DATA_DIR");
+
+    if ((datadir!=NULL) && (!libpostal_setup_datadir(datadir) || !libpostal_setup_language_classifier_datadir(datadir)) ||
+        (!libpostal_setup() || !libpostal_setup_language_classifier())) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Error loading libpostal");
     }
 
     PyModule_AddObject(module, "NULL_DUPLICATE_STATUS", PyLong_FromSsize_t(LIBPOSTAL_NULL_DUPLICATE_STATUS));

--- a/postal/pyexpand.c
+++ b/postal/pyexpand.c
@@ -227,9 +227,12 @@ init_expand(void) {
         INITERROR;
     }
 
-    if (!libpostal_setup() || !libpostal_setup_language_classifier()) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Error loading libpostal");
+   char* datadir = getenv("LIBPOSTAL_DATA_DIR");
+
+    if ((datadir!=NULL) && (!libpostal_setup_datadir(datadir) || !libpostal_setup_language_classifier_datadir(datadir)) ||
+        (!libpostal_setup() || !libpostal_setup_language_classifier())) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Error loading libpostal");
     }
 
     PyModule_AddObject(module, "ADDRESS_NONE", PyLong_FromUnsignedLongLong(LIBPOSTAL_ADDRESS_NONE));

--- a/postal/pyneardupe.c
+++ b/postal/pyneardupe.c
@@ -225,9 +225,12 @@ init_near_dupe(void) {
         INITERROR;
     }
 
-    if (!libpostal_setup() || !libpostal_setup_language_classifier()) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Error loading libpostal");
+   char* datadir = getenv("LIBPOSTAL_DATA_DIR");
+
+    if ((datadir!=NULL) && (!libpostal_setup_datadir(datadir) || !libpostal_setup_language_classifier_datadir(datadir)) ||
+        (!libpostal_setup() || !libpostal_setup_language_classifier())) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Error loading libpostal");
     }
 
 #ifndef IS_PY3K

--- a/postal/pynormalize.c
+++ b/postal/pynormalize.c
@@ -225,11 +225,13 @@ init_normalize(void) {
         INITERROR;
     }
 
-    if (!libpostal_setup()) {
-        PyErr_SetString(PyExc_RuntimeError,
-                        "Could not load libpostal");
-        Py_DECREF(module);
-        INITERROR;
+   char* datadir = getenv("LIBPOSTAL_DATA_DIR");
+
+    if ((datadir!=NULL && !libpostal_setup_datadir(datadir)) || !libpostal_setup()) {
+            PyErr_SetString(PyExc_RuntimeError,
+                            "Could not load libpostal");
+            Py_DECREF(module);
+            INITERROR;
     }
 
     PyModule_AddObject(module, "NORMALIZE_STRING_LATIN_ASCII", PyLong_FromUnsignedLongLong(LIBPOSTAL_NORMALIZE_STRING_LATIN_ASCII));

--- a/postal/pyparser.c
+++ b/postal/pyparser.c
@@ -192,9 +192,12 @@ init_parser(void) {
         INITERROR;
     }
 
-    if (!libpostal_setup() || !libpostal_setup_parser()) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Error loading libpostal data");
+   char* datadir = getenv("LIBPOSTAL_DATA_DIR");
+
+    if ((datadir!=NULL) && (!libpostal_setup_datadir(datadir) || !libpostal_setup_parser_datadir(datadir)) ||
+        (!libpostal_setup() || !libpostal_setup_parser())) {
+            PyErr_SetString(PyExc_TypeError,
+                            "Error loading libpostal data");
     }
 
 #ifndef IS_PY3K


### PR DESCRIPTION
# Summary
Add an option to change the datadir location in python.
Our use case is for running in PySpark, similar to issue openvenues/libpostal#153.

resolves #58 