### PR TITLE
Disable appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,3 @@
+branches:
+  only:
+    - never-build-branch-automatically-dont-use-this-name


### PR DESCRIPTION
The appveyor tests are failing for PRs that are fine. We're better off without it, unless someone takes the time to set it up. 
It's possible to disable the tests via the project settings:
https://help.appveyor.com/discussions/problems/6614-disable-automatic-building

This PR is quick hack to achieve the same.