### PR TITLE
Release GIL during initialization

### DIFF
--- a/postal/pyparser.c
+++ b/postal/pyparser.c
@@ -192,7 +192,9 @@ init_parser(void) {
         INITERROR;
     }
 
-   char* datadir = getenv("LIBPOSTAL_DATA_DIR");
+    Py_BEGIN_ALLOW_THREADS
+
+    char* datadir = getenv("LIBPOSTAL_DATA_DIR");
 
     if ((datadir!=NULL) && (!libpostal_setup_datadir(datadir) || !libpostal_setup_parser_datadir(datadir)) ||
         (!libpostal_setup() || !libpostal_setup_parser())) {
@@ -204,6 +206,7 @@ init_parser(void) {
     Py_AtExit(&cleanup_libpostal);
 #endif
 
+    Py_END_ALLOW_THREADS
 
 #ifdef IS_PY3K
     return module;


### PR DESCRIPTION
This helps mitigate issue #44 this way:
- trigger import of `parse_address` in a dedicated thread.
- the PR releases the GIL during the initialization so the other threads are not blocked in python code and can proceed with other tasks.
- if another thread imports `parse_address`, it will wait for the first import to complete.

Example:
```python
import threading

def _import_postal():
    from postal.parser import parse_address

threading.Thread(name='import-postal', target=_import_postal, daemon=True).start()

# do something useful until import completes
```
