### PR TITLE
fix for SetuptoolsDeprecationWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,23 @@ def main():
         license='MIT License',
         maintainer='mapzen.com',
         maintainer_email='pelias@mapzen.com',
+        classifiers=[
+            'Intended Audience :: Developers',
+            'Intended Audience :: Information Technology',
+            'License :: OSI Approved :: MIT License',
+            'Programming Language :: C',
+            'Programming Language :: Python :: 2',
+            'Programming Language :: Python :: 2.7',
+            'Programming Language :: Python :: 3',
+            'Programming Language :: Python :: 3.4',
+            'Programming Language :: Python :: 3.5',
+            'Operating System :: MacOS :: MacOS X',
+            'Operating System :: POSIX :: Linux',
+            'Topic :: Text Processing :: Linguistic',
+            'Topic :: Scientific/Engineering :: GIS',
+            'Topic :: Internet :: WWW/HTTP :: Indexing/Search',
+            'Topic :: Software Development :: Libraries :: Python Modules'
+        ],
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -87,23 +87,6 @@ def main():
         license='MIT License',
         maintainer='mapzen.com',
         maintainer_email='pelias@mapzen.com',
-        classifiers=[
-            'Intended Audience :: Developers',
-            'Intended Audience :: Information Technology',
-            'License :: OSI Approved :: MIT License',
-            'Programming Language :: C',
-            'Programming Language :: Python :: 2',
-            'Programming Language :: Python :: 2.7',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.4',
-            'Programming Language :: Python :: 3.5',
-            'Operating System :: MacOS :: MacOS X',
-            'Operating System :: POSIX :: Linux',
-            'Topic :: Text Processing :: Linguistic',
-            'Topic :: Scientific/Engineering :: GIS',
-            'Topic :: Internet :: WWW/HTTP :: Indexing/Search',
-            'Topic :: Software Development :: Libraries :: Python Modules'
-        ],
     )
 
 


### PR DESCRIPTION
Let me know if this is okay, just changed an underscore from a dash. i think it might break older builds but i dont know
SetuptoolsDeprecationWarning: Invalid dash-separated key 'description-file' in 'metadata'
      (setup.cfg), please use the underscore name 'description_file' instead.
      !!

              ********************************************************************************
              Usage of dash-separated 'description-file' will not be supported in future
              versions. Please use the underscore name 'description_file' instead.
              (Affected: postal).

              By 2026-Mar-03, you need to update your project and remove deprecated calls
              or your builds will no longer be supported.

              See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
              ********************************************************************************

      !!